### PR TITLE
fix(*): E2E 测试发现的 8 个 Bug 修复

### DIFF
--- a/backend/src/modules/builder/application/services/builder_service.py
+++ b/backend/src/modules/builder/application/services/builder_service.py
@@ -317,9 +317,13 @@ class BuilderService:
             session.add_message("assistant", full_text)
             log.info("builder_blueprint_parsed", session_id=session.id, sections=list(blueprint_dict.keys()))
         else:
-            # 没有结构化段: 可能是引导性对话, 还未到生成阶段
+            # 没有结构化段: 引导性对话, 仍需转为 CONFIRMED 以允许后续 refine (BUG-3)
             session.add_message("assistant", full_text)
-            # 不改变状态, 保持 GENERATING 等下一轮输入
+            session.complete_generation(
+                config=session.generated_config or {},
+                name=session.agent_name or "未命名 Agent",
+                blueprint=session.generated_blueprint,
+            )
             log.info("builder_no_blueprint_sections", session_id=session.id)
 
     @staticmethod

--- a/backend/tests/modules/builder/unit/application/test_builder_service_v2.py
+++ b/backend/tests/modules/builder/unit/application/test_builder_service_v2.py
@@ -263,7 +263,7 @@ tone: casual
         assert mock_session_repo.update.call_count >= 2
 
     @pytest.mark.asyncio
-    async def test_generate_blueprint_stream_no_sections_stays_generating(
+    async def test_generate_blueprint_stream_no_sections_transitions_to_confirmed(
         self,
         builder_service_v2: BuilderService,
         mock_session_repo: AsyncMock,
@@ -271,7 +271,7 @@ tone: casual
         mock_tool_querier: AsyncMock,
         mock_skill_querier: AsyncMock,
     ) -> None:
-        """LLM 返回纯引导文本 (无结构化段) 时, session 保持 GENERATING。"""
+        """LLM 返回纯引导文本 (无结构化段) 时, session 转为 CONFIRMED 以允许后续 refine。"""
         session = make_builder_session(session_id=1, user_id=100, status=BuilderStatus.PENDING)
         mock_session_repo.get_by_id.return_value = session
         mock_tool_querier.list_approved_tools.return_value = []
@@ -287,11 +287,10 @@ tone: casual
             chunks.append(chunk)
 
         assert len(chunks) == 1
-        # session 应该还是 GENERATING (没有 complete_generation)
-        # 最后一次 update 的 session 对象 status 应为 GENERATING
+        # 即使无结构化段，session 也应转为 CONFIRMED（允许后续 refine，BUG-3 修复）
         last_update_call = mock_session_repo.update.call_args_list[-1]
         saved_session = last_update_call[0][0]
-        assert saved_session.status == BuilderStatus.GENERATING
+        assert saved_session.status == BuilderStatus.CONFIRMED
 
 
 @pytest.mark.unit

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -1,34 +1,35 @@
-// AuthProvider — 桥接 Zustand auth store 与 API client token 注入 + 401 事件监听
-// + 页面加载时通过 httpOnly Cookie 自动恢复会话
+// AuthProvider — 401 事件监听 + 去抖防止循环登出
+// Token 注入已移至 auth store 的 setAuth/logout 中同步执行（BUG-7）
+// useCurrentUser 由 ProtectedRoute 调用，此处不再重复（BUG-6）
 
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { setTokenGetter, UNAUTHORIZED_EVENT } from '@/shared/api';
-import { useAuthToken, useCurrentUser, useLogout } from '@/features/auth';
+import { UNAUTHORIZED_EVENT } from '@/shared/api';
+import { useLogout } from '@/features/auth';
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const token = useAuthToken();
   const navigate = useNavigate();
   const logout = useLogout();
 
-  // 页面加载时自动尝试 /auth/me 恢复会话（httpOnly Cookie 自动携带）
-  useCurrentUser();
-
-  // 将 Zustand store 的 token getter 注入到 API client（Bearer header 仍作为 Cookie 的补充）
+  // 监听 401 未认证事件，去抖防止循环登出（BUG-6）
   useEffect(() => {
-    setTokenGetter(() => token);
-  }, [token]);
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // 监听 401 未认证事件，通过 React Router 导航到登录页（保持 SPA 体验）
-  useEffect(() => {
     const handleUnauthorized = () => {
+      if (debounceTimer) return;
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+      }, 1000);
       logout();
       navigate('/login', { replace: true });
     };
 
     window.addEventListener(UNAUTHORIZED_EVENT, handleUnauthorized);
-    return () => window.removeEventListener(UNAUTHORIZED_EVENT, handleUnauthorized);
+    return () => {
+      window.removeEventListener(UNAUTHORIZED_EVENT, handleUnauthorized);
+      if (debounceTimer) clearTimeout(debounceTimer);
+    };
   }, [logout, navigate]);
 
   return <>{children}</>;

--- a/frontend/src/features/auth/api/queries.ts
+++ b/frontend/src/features/auth/api/queries.ts
@@ -56,6 +56,8 @@ export function useCurrentUser() {
       return data;
     },
     retry: false,
+    // Token 仅存内存，无 token 时不请求 /auth/me（防止 401 轮询风暴 BUG-6）
+    enabled: !!token,
   });
 
   // 将用户信息同步到 auth store

--- a/frontend/src/features/auth/model/store.ts
+++ b/frontend/src/features/auth/model/store.ts
@@ -3,6 +3,8 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/shallow';
 
+import { setTokenGetter } from '@/shared/api';
+
 import type { UserSummary } from '@/entities/user';
 
 import type { AuthState } from './types';
@@ -11,8 +13,15 @@ const useAuthStore = create<AuthState>()((set) => ({
   user: null,
   token: null,
   isAuthenticated: false,
-  setAuth: (user: UserSummary, token: string) => set({ user, token, isAuthenticated: true }),
-  logout: () => set({ user: null, token: null, isAuthenticated: false }),
+  setAuth: (user: UserSummary, token: string) => {
+    // 同步更新 token getter，避免 navigate 后请求无 Bearer header（BUG-7）
+    setTokenGetter(() => token);
+    set({ user, token, isAuthenticated: true });
+  },
+  logout: () => {
+    setTokenGetter(() => null);
+    set({ user: null, token: null, isAuthenticated: false });
+  },
 }));
 
 // 细粒度 selector hooks — useShallow 防止无限重渲染

--- a/frontend/src/features/auth/ui/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/LoginForm.tsx
@@ -23,6 +23,7 @@ export function LoginForm() {
   });
 
   const handleFormSubmit = async (data: LoginFormData) => {
+    if (loginMutation.isPending) return; // 防止快速交互重复提交（BUG-8）
     try {
       await loginMutation.mutateAsync(data);
       navigate('/');

--- a/frontend/src/features/builder/ui/BuilderChat.tsx
+++ b/frontend/src/features/builder/ui/BuilderChat.tsx
@@ -135,6 +135,9 @@ export function BuilderChat({ onSubmitInitial, onSubmitRefine, onAbort }: Builde
         <div className="flex gap-2">
           <textarea
             ref={inputRef}
+            id="builder-prompt"
+            name="builder-prompt"
+            aria-label="Agent 需求描述"
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             rows={2}

--- a/frontend/src/pages/builder/index.tsx
+++ b/frontend/src/pages/builder/index.tsx
@@ -7,6 +7,7 @@
 import { useNavigate } from 'react-router-dom';
 
 import { useAuthToken } from '@/features/auth';
+import { useNavigationGuard } from '@/shared/hooks';
 import {
   BuilderActions,
   BuilderChat,
@@ -28,6 +29,13 @@ export default function BuilderPage() {
   const token = useAuthToken();
 
   const phase = useBuilderPhase();
+
+  // 导航守卫: 有进行中工作时阻止离开（BUG-4）
+  useNavigationGuard(
+    phase === 'generating' || phase === 'configure' || phase === 'testing',
+    '你正在构建 Agent，离开页面将丢失当前进度。确定要离开吗？',
+  );
+
   const sessionId = useBuilderSessionId();
   const createdAgentId = useBuilderCreatedAgentId();
   const { setSessionId, setConfirming, setError, setPhase, setCreatedAgentId, addMessage, reset } =
@@ -178,7 +186,7 @@ function InputPhaseHeader() {
     <div className="border-b border-gray-200 px-6 py-4">
       <div className="mx-auto max-w-2xl">
         <h2 className="text-center text-lg font-semibold text-gray-900">选择构建方式</h2>
-        <div className="mt-3 grid grid-cols-3 gap-3">
+        <div className="mt-3 grid grid-cols-3 gap-3" role="listbox" aria-label="选择构建方式">
           <StartOptionCard
             icon="📚"
             title="从 Skill 库"

--- a/frontend/src/shared/hooks/index.ts
+++ b/frontend/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
+export { useNavigationGuard } from './useNavigationGuard';
 export { useOperatingItem } from './useOperatingItem';

--- a/frontend/src/shared/hooks/useNavigationGuard.ts
+++ b/frontend/src/shared/hooks/useNavigationGuard.ts
@@ -1,0 +1,34 @@
+// 导航守卫 — 防止用户在有未保存工作时意外离开页面（BUG-4）
+
+import { useEffect } from 'react';
+import { useBlocker } from 'react-router-dom';
+
+export function useNavigationGuard(shouldBlock: boolean, message?: string) {
+  const msg = message ?? '你有未保存的更改，确定要离开吗？';
+
+  // 拦截 SPA 内导航（React Router）
+  const blocker = useBlocker(shouldBlock);
+
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      const confirmed = window.confirm(msg);
+      if (confirmed) {
+        blocker.proceed();
+      } else {
+        blocker.reset();
+      }
+    }
+  }, [blocker, msg]);
+
+  // 拦截浏览器级导航（标签关闭、刷新、外部链接）
+  useEffect(() => {
+    if (!shouldBlock) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [shouldBlock]);
+}


### PR DESCRIPTION
## Summary

E2E 测试 AI Agent 构建器页面 (https://d2k7ovgb2e4af9.cloudfront.net/builder) 发现 8 个 Bug，本 PR 全部修复。

### 认证修复 (BUG-6/7/8)
- **BUG-7**: `setAuth` 同步调用 `setTokenGetter`，消除登录后 token 竞态导致的 401
- **BUG-6**: `useCurrentUser` 添加 `enabled: !!token` + UNAUTHORIZED_EVENT 去抖，消除 49 次 401 轮询风暴
- **BUG-8**: `LoginForm.handleFormSubmit` 添加 `isPending` 守卫，防止重复登录请求

### 状态机修复 (BUG-3)
- 后端 `_try_parse_and_save_blueprint` 无结构化段时也调用 `complete_generation()` 转为 CONFIRMED，解决 "BuilderSession 不能从 generating 转换到 generating" 错误

### 无障碍修复 (BUG-1/2/5)
- 构建方式选择容器添加 `role="listbox"`
- textarea 添加 `aria-label` + `id`/`name` 属性

### UX 修复 (BUG-4)
- 新建 `useNavigationGuard` hook，Builder 有进行中工作时阻止导航离开

## Test plan

- [x] 前端 lint + typecheck 通过
- [x] auth + builder 模块 90 个测试全部通过
- [x] 后端 ruff + mypy 通过
- [x] builder 模块 85 个测试全部通过
- [ ] E2E 回归: 登录无 401 风暴 → Builder AI 生成 → 跟进对话无报错 → 导航离开有确认提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)